### PR TITLE
Support not str type (e.g., int, float) image IDs

### DIFF
--- a/map_boxes/__init__.py
+++ b/map_boxes/__init__.py
@@ -111,8 +111,8 @@ def mean_average_precision_for_boxes(ann, pred, iou_threshold=0.5, exclude_not_i
     else:
         preds = pd.DataFrame(pred, columns=['ImageID', 'LabelName', 'Conf', 'XMin', 'XMax', 'YMin', 'YMax'])
 
-    ann_unique = valid['ImageID'].unique()
-    preds_unique = preds['ImageID'].unique()
+    ann_unique = valid['ImageID'].unique().astype(np.str)
+    preds_unique = preds['ImageID'].unique().astype(np.str)
 
     if verbose:
         print('Number of files in annotations: {}'.format(len(ann_unique)))


### PR DESCRIPTION
### Problem
* An error occurs if the image ID is not of str type (e.g., int, float).
  * Keys of `all_detections` or `all_annotations` are `str`, but `ann_unique`, `preds_unique` have original type.

### Changes in this PR
* Change the type of `ann_unique` and `preds_unique` into `str`.